### PR TITLE
S3 backups

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,12 +219,18 @@ No modules.
 | [aws_iam_role_policy.avi_kms](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy.avi_r53](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy.avi_s3](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+| [aws_iam_role_policy.avi_s3_backup](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy.avi_sqs_sns](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy.avi_vmimport_kms_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy.avi_vmimport_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_instance.avi_controller](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance) | resource |
 | [aws_internet_gateway.avi](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/internet_gateway) | resource |
 | [aws_route.default_route](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route) | resource |
+| [aws_s3_bucket.s3_nsxalb_backups](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
+| [aws_s3_bucket_lifecycle_configuration.s3_nsxalb_backups](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_lifecycle_configuration) | resource |
+| [aws_s3_bucket_ownership_controls.s3_nsxalb_backups](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_ownership_controls) | resource |
+| [aws_s3_bucket_public_access_block.s3_nsxalb_backups](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
+| [aws_s3_bucket_server_side_encryption_configuration.s3_nsxalb_backups](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_server_side_encryption_configuration) | resource |
 | [aws_security_group.avi_controller_sg](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_security_group.avi_data_sg](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_security_group.avi_se_mgmt_sg](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
@@ -287,6 +293,8 @@ No modules.
 | <a name="input_private_key_path"></a> [private\_key\_path](#input\_private\_key\_path) | The local private key path for the EC2 Key pair used for authenticating to the Avi Controller. Either private\_key\_path or private\_key\_contents must be supplied. | `string` | `null` | no |
 | <a name="input_region"></a> [region](#input\_region) | The Region that the AVI controller and SEs will be deployed to | `string` | n/a | yes |
 | <a name="input_register_controller"></a> [register\_controller](#input\_register\_controller) | If enabled is set to true the controller will be registered and licensed with Avi Cloud Services. The Long Organization ID (organization\_id) can be found from https://console.cloud.vmware.com/csp/gateway/portal/#/organization/info. The jwt\_token can be retrieved at https://portal.avipulse.vmware.com/portal/controller/auth/cspctrllogin. Optionally the controller name and description used during the registration can be set; otherwise, the name\_prefix and configure\_gslb.site\_name variables will be used. | <pre>object({<br>    enabled         = bool,<br>    jwt_token       = string,<br>    email           = string,<br>    organization_id = string,<br>    name            = optional(string),<br>    description     = optional(string)<br>  })</pre> | <pre>{<br>  "email": "",<br>  "enabled": "false",<br>  "jwt_token": "",<br>  "organization_id": ""<br>}</pre> | no |
+| <a name="input_s3_backup_bucket"></a> [s3\_backup\_bucket](#input\_s3\_backup\_bucket) | Name of the S3 bucket for Controller configuration backups | `string` | `null` | no |
+| <a name="input_s3_backup_retention"></a> [s3\_backup\_retention](#input\_s3\_backup\_retention) | Number of days to keep backups in S3 bucket | `number` | `4` | no |
 | <a name="input_se_ebs_encryption"></a> [se\_ebs\_encryption](#input\_se\_ebs\_encryption) | Enable encryption on SE AMI / EBS Volumes.  The AWS Managed EBS KMS key will be used if no key is provided with se\_ebs\_encryption\_key\_arn variable | `bool` | `"true"` | no |
 | <a name="input_se_ebs_encryption_key_arn"></a> [se\_ebs\_encryption\_key\_arn](#input\_se\_ebs\_encryption\_key\_arn) | AWS Resource Name of an existing KMS key for SE AMI/EBS (se\_ebs\_encryption must be set to true) | `string` | `null` | no |
 | <a name="input_se_ha_mode"></a> [se\_ha\_mode](#input\_se\_ha\_mode) | The HA mode of the default Service Engine Group. Possible values active/active, n+m, or active/standby | `string` | `"active/active"` | no |

--- a/backups.tf
+++ b/backups.tf
@@ -1,8 +1,5 @@
 resource "aws_s3_bucket" "s3_nsxalb_backups" {
   bucket = var.s3_backup_bucket
-  lifecycle {
-    prevent_destroy = true
-  }
 }
 
 resource "aws_s3_bucket_public_access_block" "s3_nsxalb_backups" {
@@ -34,9 +31,6 @@ resource "aws_s3_bucket_lifecycle_configuration" "s3_nsxalb_backups" {
       noncurrent_days = 1
     }
     status = "Enabled"
-  }
-  lifecycle {
-    prevent_destroy = true
   }
 }
 

--- a/backups.tf
+++ b/backups.tf
@@ -1,0 +1,53 @@
+resource "aws_s3_bucket" "s3_nsxalb_backups" {
+  bucket = var.s3_backup_bucket
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "s3_nsxalb_backups" {
+  bucket = aws_s3_bucket.s3_nsxalb_backups.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_ownership_controls" "s3_nsxalb_backups" {
+  bucket = aws_s3_bucket.s3_nsxalb_backups.id
+
+  rule {
+    object_ownership = "BucketOwnerEnforced"
+  }
+}
+
+
+resource "aws_s3_bucket_lifecycle_configuration" "s3_nsxalb_backups" {
+  bucket = aws_s3_bucket.s3_nsxalb_backups.id
+  rule {
+    id = "Backup Retention"
+    expiration {
+      days = var.s3_backup_retention
+    }
+    noncurrent_version_expiration {
+      noncurrent_days = 1
+    }
+    status = "Enabled"
+  }
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "s3_nsxalb_backups" {
+  bucket = aws_s3_bucket.s3_nsxalb_backups.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      kms_master_key_id = var.se_s3_encryption_key_arn
+      sse_algorithm     = "aws:kms"
+    }
+    bucket_key_enabled = true
+  }
+}

--- a/ec2-avi.tf
+++ b/ec2-avi.tf
@@ -36,6 +36,7 @@ locals {
     portal_certificate        = var.portal_certificate
     securechannel_certificate = var.securechannel_certificate
     ca_certificates           = var.ca_certificates
+    s3_backup_bucket          = aws_s3_bucket.s3_nsxalb_backups.id
   }
   controller_names = aws_instance.avi_controller[*].tags.Name
   controller_ip    = aws_instance.avi_controller[*].private_ip

--- a/files/ansible/avi-controller-aws-all-in-one-play.yml.tpl
+++ b/files/ansible/avi-controller-aws-all-in-one-play.yml.tpl
@@ -35,6 +35,7 @@
     aws_vpc_id: ${vpc_id}
     aws_region: ${aws_region}
     name_prefix: ${name_prefix}
+    s3_backup_bucket: ${s3_backup_bucket}
     se_ha_mode: ${se_ha_mode}
     se_instance_type: ${se_instance_type}
 %{ if se_ebs_encryption_key_arn != null ~}
@@ -276,6 +277,17 @@
       register: avi_cloud
       ignore_errors: yes
 
+%{ if s3_backup_bucket != null ~}
+    - name: Set AWS S3 Backup Configuration
+      avi_backupconfiguration:
+        avi_credentials: "{{ avi_credentials }}"
+        state: present
+        name: Backup-Configuration
+        upload_to_s3: true
+        aws_bucket_id: "{{ s3_backup_bucket }}"
+        aws_bucket_region: "{{ aws_region }}"
+        backup_passphrase: "{{ password }}"
+%{ else ~}
     - name: Set Backup Passphrase
       avi_backupconfiguration:
         avi_credentials: "{{ avi_credentials }}"
@@ -283,6 +295,7 @@
         name: Backup-Configuration
         backup_passphrase: "{{ password }}"
         upload_to_remote_host: false
+%{ endif ~}
 
 %{ if se_ha_mode == "active/active" ~}
     - name: Configure SE-Group

--- a/files/ansible/avi-controller-aws-all-in-one-play.yml.tpl
+++ b/files/ansible/avi-controller-aws-all-in-one-play.yml.tpl
@@ -287,6 +287,7 @@
         aws_bucket_id: "{{ s3_backup_bucket }}"
         aws_bucket_region: "{{ aws_region }}"
         backup_passphrase: "{{ password }}"
+        upload_to_remote_host: false
 %{ else ~}
     - name: Set Backup Passphrase
       avi_backupconfiguration:

--- a/files/iam/avicontroller-s3-backup-policy.json.tpl
+++ b/files/iam/avicontroller-s3-backup-policy.json.tpl
@@ -1,0 +1,18 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "VisualEditor0",
+            "Effect": "Allow",
+            "Action": [
+                "s3:PutObject",
+                "s3:ListBucket",
+                "s3:DeleteObject"
+            ],
+            "Resource": [
+                "arn:${awsPartition}:s3:::${s3_bucket}",
+                "arn:${awsPartition}:s3:::*/*"
+            ]
+        }
+    ]
+}

--- a/iam.tf
+++ b/iam.tf
@@ -93,3 +93,10 @@ resource "aws_iam_role_policy" "avi_kms" {
 
   policy = templatefile("${path.module}/files/iam/avicontroller-kms-policy.json.tpl", { awsPartition = data.aws_partition.current.partition })
 }
+resource "aws_iam_role_policy" "avi_s3_backup" {
+  count = var.create_iam ? 1 : 0
+  name  = "${var.name_prefix}-avicontroller-s3-backup-policy"
+  role  = aws_iam_role.avi[0].id
+
+  policy = templatefile("${path.module}/files/iam/avicontroller-s3-backup-policy.json.tpl", { awsPartition = data.aws_partition.current.partition, s3_bucket = aws_s3_bucket.s3_nsxalb_backups.id })
+}

--- a/variables.tf
+++ b/variables.tf
@@ -338,3 +338,13 @@ variable "configure_gslb" {
   })
   default = { enabled = "false", site_name = "", domains = [""] }
 }
+variable "s3_backup_bucket" {
+  description = "Name of the S3 bucket for Controller configuration backups"
+  type        = string
+  default     = null
+}
+variable "s3_backup_retention" {
+  description = "Number of days to keep backups in S3 bucket"
+  type        = number
+  default     = 4
+}


### PR DESCRIPTION
Adds a new feature to enable the Configuration Backups uploaded to S3.
- Creates new S3 bucket for backups with a lifecycle retention policy
- Creates new IAM policy for AVI-Controller-Refined-Role with permissions to write to S3 bucket
- Configures the controller to enable S3 upload to the specified bucket.

DISCLAIMER: This feature is using AWS IAM Instance Profiles instead of the AWS Access and Secret keys.  This is currently unsupported as of AVI version 22.1.3.  To enable S3 upload in the current 22.1.3 release, follow the instructions in the AVI documentation to add the Access and Secret keys.
https://avinetworks.com/docs/latest/backup-and-restore-of-avi-vantage-configuration/#configuring-backup-using-amazon-s3


